### PR TITLE
Support Night mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,9 @@
 const body = document.querySelector('body')
 const nav = document.querySelector('.global-nav-inner')
 
+const prevBody = body.style.backgroundColor
+const prevNav = nav.style.backgroundColor
+
 const birdie = document.querySelector('.Icon--bird')
 birdie.id = 'timer'
 
@@ -48,7 +51,7 @@ window.setInterval(_ => update(), interval * 1000)
 birdie.addEventListener('click', () => {
   current = start + 1
   time.style.stroke = '#fff'
-  nav.style.backgroundColor = '#fff'
-  body.style.backgroundColor = '#e6ecf0'
+  nav.style.backgroundColor = prevNav
+  body.style.backgroundColor = prevBody
   update()
 })


### PR DESCRIPTION
## This PR supports night mode in twitter

**If this was intentional please ignore this PR**
Previously if we are on night mode the background would turn white when we reset timer

![prevbeha](https://user-images.githubusercontent.com/29819102/41957505-cd5856f2-7a04-11e8-81ac-2aab15257322.gif)


Now
![nightmode](https://user-images.githubusercontent.com/29819102/41957671-522cc85e-7a05-11e8-8e83-0a29378732ee.gif)

Thanks for twitter-timer sid!